### PR TITLE
Typo fix in sales invoice number and version bump.

### DIFF
--- a/netvisor_api_client/__init__.py
+++ b/netvisor_api_client/__init__.py
@@ -6,6 +6,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 from .core import Netvisor  # flake8: noqa

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -96,7 +96,7 @@ class SalesInvoiceProductLineSchema(RejectUnknownFieldsSchema):
 
 
 class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
-    sales_invoice_number = fields.Integer(attibute='number')
+    sales_invoice_number = fields.Integer(attribute='number')
     sales_invoice_date = fields.Date(attribute='date')
     sales_invoice_delivery_date = fields.Date(attribute='delivery_date')
     sales_invoice_reference_number = fields.String(attribute='reference_number')

--- a/tests/data/requests/SalesInvoice.xml
+++ b/tests/data/requests/SalesInvoice.xml
@@ -1,5 +1,6 @@
 <Root>
   <SalesInvoice>
+    <SalesInvoiceNumber>107</SalesInvoiceNumber>
     <SalesInvoiceDate>2008-12-12</SalesInvoiceDate>
     <SalesInvoiceDeliveryDate>2008-07-25</SalesInvoiceDeliveryDate>
     <SalesInvoiceReferenceNumber>1070</SalesInvoiceReferenceNumber>


### PR DESCRIPTION
Hi,

I noticed a small typo in sales invoice creation, causing a situation where you can't define a sales invoice number when creating new invoices. Additionally, I bumped the version number for you to easily release a new version with this.

Thank you for maintaining this library! Netvisor's API isn't the easiest one and this has saved quite a few hours for me already. I'm about to implement product creation and updates for this, so I'll send you that PR when done.