### PR TITLE
Value date and currency for invoices, invoice print format for customers

### DIFF
--- a/netvisor_api_client/schemas/customers/create.py
+++ b/netvisor_api_client/schemas/customers/create.py
@@ -5,7 +5,7 @@
     :copyright: (c) 2013-2016 by Fast Monkeys Oy | 2019- by Heltti Oy
     :license: MIT, see LICENSE for more details.
 """
-from marshmallow import fields
+from marshmallow import fields, post_dump
 
 from ..common import RejectUnknownFieldsSchema
 from ..fields import Boolean
@@ -65,9 +65,18 @@ class CustomerAdditionalInformationSchema(RejectUnknownFieldsSchema):
     comment = fields.String()
     customer_reference_number = fields.String()
     invoicing_language = fields.String()
+    invoice_print_channel_format = fields.Integer()
 
     class Meta:
         ordered = True
+
+    @post_dump
+    def post_dump(self, data):
+        if 'invoice_print_channel_format' in data:
+            data['invoice_print_channel_format'] = {
+                '#text': str(data['invoice_print_channel_format']),
+                '@type': 'netvisor'
+            }
 
 
 class CreateCustomerSchema(RejectUnknownFieldsSchema):

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -102,6 +102,7 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
     sales_invoice_delivery_date = fields.Date(attribute='delivery_date')
     sales_invoice_reference_number = fields.String(attribute='reference_number')
     sales_invoice_amount = Decimal(attribute='amount')
+    amount_currency = fields.String(attribute='currency')
 
     seller_identifier = fields.String()
     seller_name = fields.String()
@@ -158,6 +159,13 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
                 '#text': data['sales_invoice_status'],
                 '@type': 'netvisor'
             }
+
+        if 'amount_currency' in data:
+            data['sales_invoice_amount'] = {
+                '#text': data['sales_invoice_amount'],
+                '@iso4217currencycode': data['amount_currency']
+            }
+            del data['amount_currency']
 
         # Only add to data if there are attachments, Netvisor API doesn't like empty lists
         if 'sales_invoice_attachments' in data and data['sales_invoice_attachments']:

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -160,7 +160,7 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
                 '@type': 'netvisor'
             }
 
-        if 'amount_currency' in data:
+        if 'sales_invoice_amount_currency' in data:
             data['sales_invoice_amount'] = {
                 '#text': data['sales_invoice_amount'],
                 '@iso4217currencycode': data['sales_invoice_amount_currency']

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -163,7 +163,7 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
         if 'amount_currency' in data:
             data['sales_invoice_amount'] = {
                 '#text': data['sales_invoice_amount'],
-                '@iso4217currencycode': data['amount_currency']
+                '@iso4217currencycode': data['sales_invoice_amount_currency']
             }
             del data['amount_currency']
 

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -98,6 +98,7 @@ class SalesInvoiceProductLineSchema(RejectUnknownFieldsSchema):
 class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
     sales_invoice_number = fields.Integer(attribute='number')
     sales_invoice_date = fields.Date(attribute='date')
+    sales_invoice_value_date = fields.Date(attribute='value_date')
     sales_invoice_delivery_date = fields.Date(attribute='delivery_date')
     sales_invoice_reference_number = fields.String(attribute='reference_number')
     sales_invoice_amount = Decimal(attribute='amount')

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -165,7 +165,7 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
                 '#text': data['sales_invoice_amount'],
                 '@iso4217currencycode': data['sales_invoice_amount_currency']
             }
-            del data['amount_currency']
+            del data['sales_invoice_amount_currency']
 
         # Only add to data if there are attachments, Netvisor API doesn't like empty lists
         if 'sales_invoice_attachments' in data and data['sales_invoice_attachments']:

--- a/netvisor_api_client/schemas/sales_invoices/create.py
+++ b/netvisor_api_client/schemas/sales_invoices/create.py
@@ -102,7 +102,7 @@ class CreateSalesInvoiceSchema(RejectUnknownFieldsSchema):
     sales_invoice_delivery_date = fields.Date(attribute='delivery_date')
     sales_invoice_reference_number = fields.String(attribute='reference_number')
     sales_invoice_amount = Decimal(attribute='amount')
-    amount_currency = fields.String(attribute='currency')
+    sales_invoice_amount_currency = fields.String(attribute='currency')
 
     seller_identifier = fields.String()
     seller_name = fields.String()

--- a/tests/data/requests/Customer.xml
+++ b/tests/data/requests/Customer.xml
@@ -38,6 +38,7 @@
       <Comment>Kommentti</Comment>
       <CustomerReferenceNumber>1070</CustomerReferenceNumber>
       <InvoicingLanguage>FI</InvoicingLanguage>
+      <InvoicePrintChannelFormat type="netvisor">1</InvoicePrintChannelFormat>
     </CustomerAdditionalInformation>
   </Customer>
 </Root>

--- a/tests/data/requests/SalesInvoice.xml
+++ b/tests/data/requests/SalesInvoice.xml
@@ -5,7 +5,7 @@
     <SalesInvoiceValueDate>2008-11-31</SalesInvoiceValueDate>
     <SalesInvoiceDeliveryDate>2008-07-25</SalesInvoiceDeliveryDate>
     <SalesInvoiceReferenceNumber>1070</SalesInvoiceReferenceNumber>
-    <SalesInvoiceAmount>244,00</SalesInvoiceAmount>
+    <SalesInvoiceAmount iso4217currencycode="EUR">244,00</SalesInvoiceAmount>
     <SellerIdentifier type="netvisor">32</SellerIdentifier>
     <SalesInvoiceStatus type="netvisor">unsent</SalesInvoiceStatus>
     <InvoicingCustomerIdentifier type="netvisor">1</InvoicingCustomerIdentifier>

--- a/tests/data/requests/SalesInvoice.xml
+++ b/tests/data/requests/SalesInvoice.xml
@@ -2,6 +2,7 @@
   <SalesInvoice>
     <SalesInvoiceNumber>107</SalesInvoiceNumber>
     <SalesInvoiceDate>2008-12-12</SalesInvoiceDate>
+    <SalesInvoiceValueDate>2008-11-31</SalesInvoiceValueDate>
     <SalesInvoiceDeliveryDate>2008-07-25</SalesInvoiceDeliveryDate>
     <SalesInvoiceReferenceNumber>1070</SalesInvoiceReferenceNumber>
     <SalesInvoiceAmount>244,00</SalesInvoiceAmount>


### PR DESCRIPTION
Hi there,

Two small incremental changes here:
- Allow specifying a value date for invoice, as it can differ from actual invoicing date.
- Allow specifying invoice print channel format for customers. This allows for international invoices to be printed without the bank transfer details usually included at the bottom of the invoice.

Both changes are included in test data, and tested against the Netvisor API.

Thank you!