### PR TITLE
Fixed accounting dimension's Item None value error.

### DIFF
--- a/netvisor_api_client/schemas/accounting/list.py
+++ b/netvisor_api_client/schemas/accounting/list.py
@@ -12,7 +12,7 @@ from ..fields import Decimal, FinnishDate, List
 
 class DimensionSchema(Schema):
     name = fields.String(load_from='dimension_name')
-    item = fields.String(load_from='dimension_item')
+    item = fields.String(load_from='dimension_item', allow_none=True)
 
 
 class VoucherLineSchema(Schema):

--- a/tests/data/responses/AccountingList.xml
+++ b/tests/data/responses/AccountingList.xml
@@ -63,5 +63,26 @@
       <LinkedSourceNetvisorKey type="salesinvoice">38</LinkedSourceNetvisorKey>
       <VoucherNetvisorURI>https:/netvisor.com/voucher/39</VoucherNetvisorURI>
     </Voucher>
+    <Voucher Status="valid">
+      <NetvisorKey>38</NetvisorKey>
+      <VoucherDate>2.1.2000</VoucherDate>
+      <VoucherNumber>39</VoucherNumber>
+      <VoucherDescription>Invoice 39</VoucherDescription>
+      <VoucherClass>SA Sales Invoice</VoucherClass>
+      <LinkedSourceNetvisorKey type="salesinvoice">39</LinkedSourceNetvisorKey>
+      <VoucherNetvisorURI>https:/netvisor.com/voucher/39</VoucherNetvisorURI>
+      <VoucherLine>
+        <NetvisorKey>300</NetvisorKey>
+        <LineSum>-30,31</LineSum>
+        <Description>Invoice 39</Description>
+        <AccountNumber>300</AccountNumber>
+        <VatPercent>33</VatPercent>
+        <VatCode>-</VatCode>
+        <Dimension>
+            <DimensionName>Sales</DimensionName>
+            <DimensionItem> </DimensionItem>
+        </Dimension>
+      </VoucherLine>
+    </Voucher>
   </Vouchers>
 </Root>

--- a/tests/services/test_accounting.py
+++ b/tests/services/test_accounting.py
@@ -86,6 +86,32 @@ class TestAccountingService(object):
                 'linked_source': {'type': 'salesinvoice', 'key': 38},
                 'uri': 'https:/netvisor.com/voucher/39',
                 'lines': []
+            },
+                        {
+                'status': 'valid',
+                'key': 38,
+                'date': date(2000, 1, 2),
+                'number': 39,
+                'description': 'Invoice 39',
+                'class': 'SA Sales Invoice',
+                'linked_source': {'type': 'salesinvoice', 'key': 39},
+                'uri': 'https:/netvisor.com/voucher/39',
+                'lines': [
+                    {
+                        'key': 300,
+                        'line_sum': Decimal('-30.31'),
+                        'description': 'Invoice 39',
+                        'account_number': 300,
+                        'vat_percent': 33,
+                        'vat_code': '-',
+                        'dimensions': [
+                            {
+                                'name': 'Sales',
+                                'item': None
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 


### PR DESCRIPTION
I have experienced that Item's code can be space (None), which have to take in account or the marshmallow crashed.