### PR TITLE
Sales invoices: invoice status to attributed version

### DIFF
--- a/netvisor_api_client/schemas/sales_invoices/get.py
+++ b/netvisor_api_client/schemas/sales_invoices/get.py
@@ -149,6 +149,6 @@ class GetSalesInvoiceSchema(Schema):
         load_from='sales_invoice_private_comment'
     )
     seller_identifier = fields.Nested(StringSchema)
-    invoice_status = fields.String(required=True)
+    invoice_status = fields.Nested(StringSchema)
     invoice_lines = fields.Nested(InvoiceLinesSchema)
     match_partial_payments_by_default = Boolean(true='Yes', false='No')

--- a/tests/data/responses/GetSalesInvoice.xml
+++ b/tests/data/responses/GetSalesInvoice.xml
@@ -12,7 +12,7 @@
     <SalesInvoiceReferencenumber>1070</SalesInvoiceReferencenumber>
     <SalesInvoiceAmount iso4217currencycode="EUR" currencyrate="1">244,00</SalesInvoiceAmount>
     <SellerIdentifier type="name">Jarmo</SellerIdentifier>
-    <InvoiceStatus>Unsent</InvoiceStatus>
+    <InvoiceStatus status="unsent">Unsent</InvoiceStatus>
     <SalesInvoiceFreeTextBeforeLines />
     <SalesInvoiceFreeTextAfterLines />
     <SalesInvoiceOurReference />

--- a/tests/data/responses/GetSalesInvoiceMinimal.xml
+++ b/tests/data/responses/GetSalesInvoiceMinimal.xml
@@ -12,7 +12,7 @@
     <SalesInvoiceReferencenumber>1070</SalesInvoiceReferencenumber>
     <SalesInvoiceAmount>244,00</SalesInvoiceAmount>
     <SellerIdentifier type="name" />
-    <InvoiceStatus>Unsent</InvoiceStatus>
+    <InvoiceStatus status="unsent">Unsent</InvoiceStatus>
     <SalesInvoiceFreeTextBeforeLines />
     <SalesInvoiceFreeTextAfterLines />
     <SalesInvoiceOurReference />


### PR DESCRIPTION
Hi there!

Pandemics come and go, but we can count on Netvisor to break stable versions. :P

Netvisor API was [updated last Thursday](https://community.visma.com/t5/Netvisor-uutiset/Viikkopaivitys-28-1-2021-julkaisutiedote/ba-p/355904) to include invoice status as an attribute. This change breaks fetching invoices from all current versions of netvisor-api-client.

I've changed the field to use StringSchema and updated tests to reflect the current API schema. Could you bump the version and push a new one if the fix in this PR is acceptable to you? Thank you!