### PR TITLE
Version support & linter fixes: py37, flake8, encodings

### DIFF
--- a/tests/services/test_company.py
+++ b/tests/services/test_company.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from datetime import date
 
 from tests.utils import get_response_content

--- a/tests/services/test_customer.py
+++ b/tests/services/test_customer.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import decimal
 
 import pytest

--- a/tests/services/test_sales_invoice.py
+++ b/tests/services/test_sales_invoice.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import decimal
 from datetime import date
 

--- a/tests/services/test_sales_payment.py
+++ b/tests/services/test_sales_payment.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import decimal
 from datetime import date
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,lint
+envlist = py27,py33,py34,py35,py37,pypy,lint
 
 [testenv]
 deps = -rrequirements.txt
@@ -8,6 +8,6 @@ commands = py.test {posargs}
 [testenv:lint]
 deps = -rrequirements.txt
 commands =
-    flake8 netvisor/ tests/
+    flake8 netvisor_api_client/ tests/
     isort --recursive --diff .
     isort --recursive --check-only .


### PR DESCRIPTION
Tox tests now include running the testsuite for Python 3.7. Personally I'd drop everything below 3.5, but didn't include removing those as it's obviously your decision to make.

In addition, I fixed path for flake8 to work and fixed some warnings it gave about missing encoding. There's still quite a lot to fix in type safety, but style could be easily enforced with [black](https://github.com/psf/black). If you're interested, I could add it to be run by tox in this same PR.